### PR TITLE
Line 124 - Warning [2] Missing argument 2

### DIFF
--- a/mytwconnect.php
+++ b/mytwconnect.php
@@ -121,8 +121,8 @@ if ($mybb->input['action'] == 'register') {
 			$db->update_query('users', $settingsToAdd, 'uid = ' . (int) $user['uid']);
 			
 			// Sync
-			$newUser = array_merge($user, $settingsToAdd);
-			$TwitterConnect->sync($newUser);
+			//$newUser = array_merge($user, $settingsToAdd);
+			$TwitterConnect->sync($newUser, $settingsToAdd);
 			
 			// Login
 			$TwitterConnect->login($user);


### PR DESCRIPTION
The method sync was executed with just one parameter and a merge was being done before execution.

I believe the method already does everything that's required so the merge is not needed? It work without it in any case, tested.

This error was being generated: Warning [2] Missing argument 2 for MyTwitter::sync()  and it stopped the automatic login process, and showed 3 other header errors.

The registration was working, but there were errors and no automatic login.

I checked the class_twitter.php in git as well and it requires both parameters so either this way or set the second parameter for sync to $data = array().

Hope it helped.
