### PR TITLE
$process['error'] contained array

### DIFF
--- a/mytwconnect.php
+++ b/mytwconnect.php
@@ -68,11 +68,17 @@ if ($mybb->input['action'] == 'do_login') {
 		
 		if ($process['error']) {
 			if (is_array($process['error']))
-			  foreach ($process['error'] as $err)
-			    $errors .= $err;
+			{
+			
+				foreach ($process['error'] as $err)
+				{
+					$errors .= $err;
+				}
+			}
 			else 
+			{
 			  $errors = $process['error'];
-			  
+			}
 			$mybb->input['action'] = 'register';
 		}
 	}


### PR DESCRIPTION
I tested 10 times and everything $errors contained an array and it was displayed to the user the word "array" instead of the error messages within.

Looks like process returned and array with one element containing the You have not specified an email error. So I just added this extra check that should handle any possible case trowed at it.

:-?
