### PR TITLE
Fix language variable in the plugin file

### DIFF
--- a/inc/plugins/mytwconnect.php
+++ b/inc/plugins/mytwconnect.php
@@ -468,7 +468,7 @@ function mytwconnect_usercp()
 			}
 			
 			$text = $lang->setting_mytwconnect_whattosync;
-			$unlink = "<input type=\"submit\" class=\"button\" name=\"unlink\" value=\"{$lang->setting_mytwconnect_unlink}\" />";
+			$unlink = "<input type=\"submit\" class=\"button\" name=\"unlink\" value=\"{$lang->mytwconnect_settings_unlink}\" />";
 			
 			if ($userSettings) {
 			


### PR DESCRIPTION
Español:

Corregir una de las variables de idioma.

En el archivo original se encuentra como:

setting_mytwconnect_unlink

En los archivos de idioma dice:
## mytwconnect_settings_unlink

English:

Correct one of the language variables.

The original file is found as:

setting_mytwconnect_unlink

In the language files says:
## mytwconnect_settings_unlink
